### PR TITLE
Bugfixes and Improvement

### DIFF
--- a/imu_an_spatial.orogen
+++ b/imu_an_spatial.orogen
@@ -11,14 +11,13 @@ version "0.1"
 # conventions, a common use-case would be:
 #
 using_library "imu_an_spatial"
-using_library "mb500"
+import_types_from "gps_base"
 
 # import_types_from "imu_an_spatial/CustomType.hpp"
 
 # If this project uses data types that are defined in other oroGen projects,
 # these projects should be imported there as well.
 import_types_from "base"
-import_types_from "gps_types.hh"
 
 # Declare a new task context (i.e., a component)
 #
@@ -54,7 +53,7 @@ task_context "Task" do
     # if this output is connected to an input or not.
     output_port "imu_samples", "base/samples/IMUSensors"
     output_port "imu_pose", "base/samples/RigidBodyState"
-    output_port "gps_solution", "/gps/Solution"
+    output_port "gps_solution", "/gps_base/Solution"
 
     # If you want that component's updateHook() to be executed when the "input"
     # port gets data, uncomment this and comment the 'periodic' line

--- a/imu_an_spatial.orogen
+++ b/imu_an_spatial.orogen
@@ -37,20 +37,11 @@ task_context "Task" do
     property("NED2NWU", "bool", true).
         doc 'Switch IMU axis convention from NED(Advanced Navigation default) to NWU(Rock default)' 
     property("local_cartesian_origin", "base/Vector3d").doc("Origin of local cartesion coordinate system in lat/lon/height")
+    property("external_velocity_std_dev", "float", 0.001)
 
-    # An input port, i.e. an object from which the component gets data from
-    # other components' outputs
-    #
-    # Data can be retrieved using _input.read(value), which returns true if data
-    # was available, and false otherwise. _input.connected() returns if this
-    # input is connected to an output or not.
-    #input_port "input", "/std/string"
+    #Input of external velocity. e.g. odometry in robot frame
+    input_port "external_velocity_in", "/base/samples/RigidBodyState"
 
-    # An output port, i.e. an object to which the component pushes data so that
-    # it is transmitted to other components' inputs
-    #
-    # Data can be written using _output.write(value). _output.connected() returns
-    # if this output is connected to an input or not.
     output_port "imu_samples", "base/samples/IMUSensors"
     output_port "imu_pose", "base/samples/RigidBodyState"
     output_port "gps_solution", "/gps_base/Solution"

--- a/manifest.xml
+++ b/manifest.xml
@@ -16,6 +16,6 @@
   -->
   <depend package="base/types" />
   <depend package="drivers/imu_an_spatial" />
-  <depend package="drivers/mb500" />
-  <depend package="geographic" />
+  <depend package="drivers/gps_base" />
+  <!--depend package="geographic" /-->
 </package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -16,6 +16,6 @@
   -->
   <depend package="base/types" />
   <depend package="drivers/imu_an_spatial" />
-  <depend package="drivers/gps_base" />
+  <depend package="drivers/orogen/gps_base" />
   <!--depend package="geographic" /-->
 </package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,5 +17,5 @@
   <depend package="base/types" />
   <depend package="drivers/imu_an_spatial" />
   <depend package="drivers/orogen/gps_base" />
-  <!--depend package="geographic" /-->
+  <depend package="geographic" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -4,7 +4,6 @@
 #include <rtt/extras/FileDescriptorActivity.hpp>
 #include <math.h>
 #include <imu_an_spatial/rs232/rs232.h>
-#include <imu_an_spatial/an_packet_protocol.h>
 #include <base-logging/Logging.hpp>
 #include <base/Time.hpp>
 #include <iostream>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -65,8 +65,11 @@ void Task::updateHook()
 
     base::samples::IMUSensors imu_sample;
     base::samples::RigidBodyState imu_pose;
-    gps::Solution sol;
+    gps_base::Solution sol;
+    base::samples::RigidBodyState external_velocity;
+    gps_base::Errors errors;
 
+    
     if (fd_activity)
     {
         if (fd_activity->hasError())
@@ -139,14 +142,15 @@ void Task::updateHook()
 
                             gnss_fix_type_e gnss_fix_type = static_cast<gnss_fix_type_e>(system_state_packet.filter_status.b.gnss_fix_type);
                             switch(gnss_fix_type){
-                                case gnss_fix_none: sol.positionType = gps::NO_SOLUTION; break;
-                                case gnss_fix_2d: sol.positionType = gps::AUTONOMOUS_2D; break;
-                                case gnss_fix_3d: sol.positionType = gps::AUTONOMOUS; break;
-                                case gnss_fix_sbas: sol.positionType = gps::DIFFERENTIAL; break;
-                                case gnss_fix_differential: sol.positionType = gps::DIFFERENTIAL; break;
-                                case gnss_fix_rtk_float: sol.positionType = gps::RTK_FLOAT; break;
-                                case gnss_fix_rtk_fixed: sol.positionType = gps::RTK_FIXED; break;
-                                default: sol.positionType = gps::INVALID; break;
+                                case gnss_fix_none: sol.positionType = gps_base::NO_SOLUTION; break;
+                                case gnss_fix_2d: sol.positionType = gps_base::AUTONOMOUS_2D; break;
+                                case gnss_fix_3d: sol.positionType = gps_base::AUTONOMOUS; break;
+                                case gnss_fix_sbas: sol.positionType = gps_base::DIFFERENTIAL; break;
+                                case gnss_fix_differential: sol.positionType = gps_base::DIFFERENTIAL; break;
+                                case gnss_fix_rtk_float: sol.positionType = gps_base::RTK_FLOAT; break;
+                                case gnss_fix_rtk_fixed: sol.positionType = gps_base::RTK_FIXED; break;
+                                case gnss_fix_omnistar: sol.positionType = gps_base::OMNISTAR; break;
+                                default: sol.positionType = gps_base::INVALID; break;
                             }
 
                             sol.latitude = system_state_packet.latitude * RADIANS_TO_DEGREES;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -89,7 +89,7 @@ void Task::updateHook()
         }
         else
         {
-            while(_external_velocity_in.read(external_velocity)){
+            while(_external_velocity_in.read(external_velocity) == RTT::NewData){
                 an_packet_t* an_packet;
                 external_body_velocity_packet_t body_vel_packet;
                 memset(&body_vel_packet, 0, sizeof(external_body_velocity_packet_t));

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -166,9 +166,9 @@ void Task::updateHook()
                                 case gnss_fix_3d: sol.positionType = gps_base::AUTONOMOUS; break;
                                 case gnss_fix_sbas: sol.positionType = gps_base::DIFFERENTIAL; break;
                                 case gnss_fix_differential: sol.positionType = gps_base::DIFFERENTIAL; break;
+                                case gnss_fix_omnistar: sol.positionType = gps_base::DIFFERENTIAL; break;
                                 case gnss_fix_rtk_float: sol.positionType = gps_base::RTK_FLOAT; break;
                                 case gnss_fix_rtk_fixed: sol.positionType = gps_base::RTK_FIXED; break;
-                                case gnss_fix_omnistar: sol.positionType = gps_base::OMNISTAR; break;
                                 default: sol.positionType = gps_base::INVALID; break;
                             }
 


### PR DESCRIPTION
This PR contains three changes:
1) Correction of imports. Software package `gps_base` defines common types for GPS devices `mb500` shoud not be further used for that purpose.
2) Feed external velocity into Advanced Navigation driver. Localization performance can significantly increased if system velocity can be fed into the D-GPS driver (e.g. originating from wheel odometry). An input port has been created and data is forwarded to the driver accordingly.
3) Advanced Navigation driver provides the GPS solution type `gnss_fix_omnistar`. In https://github.com/rock-drivers/drivers-gps_base/pull/7 `gps_base` is extended with the value `OMNISTAR` to reflect this. This component here is extended to set the value accordingly.

**Depends on https://github.com/rock-drivers/drivers-gps_base/pull/7 DO NOT MERGE BEFORE**